### PR TITLE
feat: update dnsprove to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tradetrust-tt/dnsprove": "^2.10.1",
+        "@tradetrust-tt/dnsprove": "^2.12.0",
         "@tradetrust-tt/document-store": "^3.1.0",
         "@tradetrust-tt/token-registry": "^4.6.0",
         "@tradetrust-tt/tradetrust": "^6.9.0",
@@ -4621,9 +4621,9 @@
       }
     },
     "node_modules/@tradetrust-tt/dnsprove": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tradetrust-tt/dnsprove/-/dnsprove-2.10.1.tgz",
-      "integrity": "sha512-C3ytoN0byLGHAMvm+rs0ErcDRAStk8o5NVUlGR8syLa/MQoXjdhMubEQo/vndytqhxipjNgKGvD0cF4G6ZTsYQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@tradetrust-tt/dnsprove/-/dnsprove-2.12.0.tgz",
+      "integrity": "sha512-PoR66us8CJwi8LOeOWQjN7cNm1ezlmkZU6pmm7jWhmE2Z491a/hHCPaSL9o6C0uh/w49TLX7eyV/oo4jcB6tNw==",
       "dependencies": {
         "axios": "^1.6.3",
         "debug": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@tradetrust-tt/dnsprove": "^2.10.1",
+    "@tradetrust-tt/dnsprove": "^2.12.0",
     "@tradetrust-tt/tradetrust": "^6.9.0",
     "@tradetrust-tt/document-store": "^3.1.0",
     "@tradetrust-tt/token-registry": "^4.6.0",


### PR DESCRIPTION
## Summary

Add support for Polygon Amoy Testnet

## Changes

- update dnsprove to 2.12.0 which has support for Polygon Amoy Testnet

