### PR TITLE
fix: upgrade dnsprove

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@govtechsg/oa-did-sign": "^2.2.0",
-        "@tradetrust-tt/dnsprove": "^2.12.0",
+        "@tradetrust-tt/dnsprove": "^2.12.2",
         "@tradetrust-tt/document-store": "^2.7.0",
         "@tradetrust-tt/token-registry": "^4.9.0",
         "@tradetrust-tt/tradetrust": "^6.9.0",
@@ -5301,11 +5301,11 @@
       }
     },
     "node_modules/@tradetrust-tt/dnsprove": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@tradetrust-tt/dnsprove/-/dnsprove-2.12.0.tgz",
-      "integrity": "sha512-PoR66us8CJwi8LOeOWQjN7cNm1ezlmkZU6pmm7jWhmE2Z491a/hHCPaSL9o6C0uh/w49TLX7eyV/oo4jcB6tNw==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@tradetrust-tt/dnsprove/-/dnsprove-2.12.2.tgz",
+      "integrity": "sha512-PK2T7dlUZNgXxY6xl11OZACPUYXTDGhrg32H6aKAUMk/PUQ5BUcAlR7esMdl8uIxRuIxN04XGICBgvx/sAJSKQ==",
       "dependencies": {
-        "axios": "^1.6.3",
+        "axios": "0.21.1",
         "debug": "^4.3.1",
         "runtypes": "^6.3.0"
       },
@@ -5314,32 +5314,11 @@
       }
     },
     "node_modules/@tradetrust-tt/dnsprove/node_modules/axios": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "dependencies": {
-        "follow-redirects": "^1.15.4",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@tradetrust-tt/dnsprove/node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
+        "follow-redirects": "^1.10.0"
       }
     },
     "node_modules/@tradetrust-tt/document-store": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@govtechsg/oa-did-sign": "^2.2.0",
-    "@tradetrust-tt/dnsprove": "^2.12.0",
+    "@tradetrust-tt/dnsprove": "^2.12.2",
     "@tradetrust-tt/document-store": "^2.7.0",
     "@tradetrust-tt/token-registry": "^4.9.0",
     "@tradetrust-tt/tradetrust": "^6.9.0",


### PR DESCRIPTION
## Summary
What is the background of this pull request?

update dnsprove as the previous version can not query dns

## Changes
update dnsprove to version 2.12.2