### PR TITLE
fix: unable to verify net=ethereum in dns txt for hedera documents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@govtechsg/oa-did-sign": "^2.2.0",
-        "@tradetrust-tt/dnsprove": "^2.12.3",
+        "@tradetrust-tt/dnsprove": "^2.12.4",
         "@tradetrust-tt/document-store": "^2.7.0",
         "@tradetrust-tt/token-registry": "^4.9.0",
         "@tradetrust-tt/tradetrust": "^6.9.0",
@@ -5301,9 +5301,9 @@
       }
     },
     "node_modules/@tradetrust-tt/dnsprove": {
-      "version": "2.12.3",
-      "resolved": "https://registry.npmjs.org/@tradetrust-tt/dnsprove/-/dnsprove-2.12.3.tgz",
-      "integrity": "sha512-JTs6ei1Hh/P9uEMfFSwckF8lA8f2g9Q5ISRX5dLkNwZFsDbLH9maMNytTOvq8+GRw+vRatBZdyR84fGFA39wRA==",
+      "version": "2.12.4",
+      "resolved": "https://registry.npmjs.org/@tradetrust-tt/dnsprove/-/dnsprove-2.12.4.tgz",
+      "integrity": "sha512-tE/AbXe26bAK0xm+boxzUqmrKfV+Iy48a/dJbfroZXf3OmKYTAOeXU20zfnvSzK24Nzl6n/PAkkrg73mcdjuhw==",
       "dependencies": {
         "axios": "0.21.1",
         "debug": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@govtechsg/oa-did-sign": "^2.2.0",
-    "@tradetrust-tt/dnsprove": "^2.12.3",
+    "@tradetrust-tt/dnsprove": "^2.12.4",
     "@tradetrust-tt/document-store": "^2.7.0",
     "@tradetrust-tt/token-registry": "^4.9.0",
     "@tradetrust-tt/tradetrust": "^6.9.0",


### PR DESCRIPTION
## Summary

When verifying hedera documents, if the dns-txt record is net=ethereum, the verification will fail with invalid issuer identity as ethereum is not the valid net name for hedera