### PR TITLE
fix: replace hardcoded key with env in tests

### DIFF
--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -1,3 +1,4 @@
+import { INFURA_API_KEY } from "../config";
 import { AllVerificationFragment } from "..";
 import { InvalidVerificationFragment, ProviderDetails } from "../types/core";
 import {
@@ -281,12 +282,12 @@ describe("generateProvider", () => {
     const options = {
       network: "sepolia",
       providerType: "infura",
-      apiKey: "bb46da3f80e040e8ab73c0a9ff365d18",
+      apiKey: INFURA_API_KEY,
     } as ProviderDetails;
     const provider = generateProvider(options) as any;
 
     expect(provider?._network?.name).toEqual("sepolia");
-    expect(provider?.apiKey).toEqual("bb46da3f80e040e8ab73c0a9ff365d18");
+    expect(provider?.apiKey).toEqual(INFURA_API_KEY);
     expect(provider?.connection?.url).toMatch(/(infura)/i);
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to use environment-based API key management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->