### PR TITLE
fix: bump dnsprove and add DID resolver fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tradetrust-tt/dnsprove": "^2.20.0",
+        "@tradetrust-tt/dnsprove": "^2.21.0",
         "@tradetrust-tt/token-registry": "^5.5.0",
         "@tradetrust-tt/tradetrust": "^6.10.3",
         "@trustvc/document-store": "^1.0.3",
@@ -3712,10 +3712,9 @@
       "license": "MIT"
     },
     "node_modules/@tradetrust-tt/dnsprove": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@tradetrust-tt/dnsprove/-/dnsprove-2.20.0.tgz",
-      "integrity": "sha512-mSyig2LD080oyK8XGQIk4B5OJF0hAAqES6HpMM9UALgnHuLM9jtCsM5hMQWrpWqx+gEebPJ4gW99Xg1hjzq+3w==",
-      "license": "Apache-2.0",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@tradetrust-tt/dnsprove/-/dnsprove-2.21.0.tgz",
+      "integrity": "sha512-acxJGS07WLfLDli1E4uvT5IbPcmh9vzVelgEdhxzi2KE50r3k/vvkwUQl1ctgkw152cIxnqR20cch8x3HLLvcw==",
       "dependencies": {
         "axios": "1.7.2",
         "debug": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@tradetrust-tt/dnsprove": "^2.20.0",
+    "@tradetrust-tt/dnsprove": "^2.21.0",
     "@tradetrust-tt/token-registry": "^5.5.0",
     "@tradetrust-tt/tradetrust": "^6.10.3",
     "@trustvc/document-store": "^1.0.3",

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -83,15 +83,14 @@ export const generateProvider = (options?: ProviderDetails): providers.Provider 
     case "infura":
       return apiKey ? new providers.InfuraProvider(network, apiKey) : new providers.InfuraProvider(network);
 
-    case "alchemy":
-      if (apiKey) {
-        return network === "sepolia"
-          ? new providers.JsonRpcProvider(`https://eth-sepolia.g.alchemy.com/v2/${apiKey}`, network)
-          : new providers.AlchemyProvider(network, apiKey);
-      }
-      return network === "sepolia"
-        ? new providers.JsonRpcProvider(`https://eth-sepolia.g.alchemy.com/v2/`, network)
-        : new providers.AlchemyProvider(network);
+    case "alchemy": {
+      // Let ethers' AlchemyProvider resolve the key (uses provided apiKey, or its built-in demo key when none given).
+      // We then construct the URL manually with the live `g.alchemy.com` host, since AlchemyProvider's mainnet URL
+      // still points at the deprecated `eth-mainnet.alchemyapi.io` domain.
+      const urlNetwork = network === "homestead" ? "mainnet" : network;
+      const resolvedKey = (new providers.AlchemyProvider(network, apiKey || undefined) as any).apiKey;
+      return new providers.JsonRpcProvider(`https://eth-${urlNetwork}.g.alchemy.com/v2/${resolvedKey}`, network);
+    }
 
     case "jsonrpc":
       return new providers.JsonRpcProvider(url);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,1 +1,2 @@
-export const INFURA_API_KEY = process.env.INFURA_API_KEY || "bb46da3f80e040e8ab73c0a9ff365d18";
+export const INFURA_API_KEY = process.env.INFURA_API_KEY || "";
+export const ALCHEMY_API_KEY = process.env.ALCHEMY_API_KEY || "";

--- a/src/did/resolver.test.ts
+++ b/src/did/resolver.test.ts
@@ -3,7 +3,7 @@ import { ethers } from "ethers";
 import { INFURA_API_KEY } from "../config";
 import { openAttestationDidIdentityProof } from "../verifiers/issuerIdentity/did/didIdentityProof";
 import { verificationBuilder } from "../verifiers/verificationBuilder";
-import { createResolver, EthrResolverConfig, getProviderConfig, resolve } from "./resolver";
+import { createResolver, EthrResolverConfig, getFallbackConfig, getProviderConfig, resolve } from "./resolver";
 
 const didDoc = {
   "@context": [
@@ -146,6 +146,73 @@ describe("getProviderConfig", () => {
   it("should set defaults when no connection url and network is found in provider parameter object", () => {
     expect(getProviderConfig()).toEqual({
       networks: [{ name: "mainnet", rpcUrl: "https://mainnet.infura.io/v3/84842078b09946638c03157f83405213" }],
+    });
+  });
+});
+
+describe("getFallbackConfig", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      PROVIDER_NETWORK: "",
+      PROVIDER_API_KEY: "",
+      PROVIDER_ENDPOINT_TYPE: "",
+      PROVIDER_ENDPOINT_URL: "",
+      INFURA_API_KEY: "",
+      ALCHEMY_API_KEY: "",
+    };
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.spyOn(console, "warn").mockRestore();
+  });
+
+  it("should fall back to Alchemy when primary defaults to Infura", () => {
+    expect(getFallbackConfig()).toEqual({
+      networks: [{ name: "mainnet", rpcUrl: "https://eth-mainnet.g.alchemy.com/v2/_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC" }],
+    });
+  });
+
+  it("should fall back to Infura when primary is Alchemy", () => {
+    process.env.PROVIDER_ENDPOINT_TYPE = "alchemy";
+
+    expect(getFallbackConfig()).toEqual({
+      networks: [{ name: "mainnet", rpcUrl: "https://mainnet.infura.io/v3/84842078b09946638c03157f83405213" }],
+    });
+  });
+
+  it("should fall back to Alchemy when primary is jsonrpc", () => {
+    process.env.PROVIDER_ENDPOINT_TYPE = "jsonrpc";
+
+    expect(getFallbackConfig()).toEqual({
+      networks: [{ name: "mainnet", rpcUrl: "https://eth-mainnet.g.alchemy.com/v2/_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC" }],
+    });
+  });
+
+  it("should honor PROVIDER_NETWORK when building Alchemy fallback", () => {
+    process.env.PROVIDER_NETWORK = "goerli";
+
+    expect(getFallbackConfig()).toEqual({
+      networks: [{ name: "goerli", rpcUrl: "https://eth-goerli.g.alchemy.com/v2/_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC" }],
+    });
+  });
+
+  it("should use ALCHEMY_API_KEY env var when set", () => {
+    process.env.ALCHEMY_API_KEY = "my-alchemy-key";
+
+    expect(getFallbackConfig()).toEqual({
+      networks: [{ name: "mainnet", rpcUrl: "https://eth-mainnet.g.alchemy.com/v2/my-alchemy-key" }],
+    });
+  });
+
+  it("should use INFURA_API_KEY env var when set and primary is Alchemy", () => {
+    process.env.PROVIDER_ENDPOINT_TYPE = "alchemy";
+    process.env.INFURA_API_KEY = "my-infura-key";
+
+    expect(getFallbackConfig()).toEqual({
+      networks: [{ name: "mainnet", rpcUrl: "https://mainnet.infura.io/v3/my-infura-key" }],
     });
   });
 });

--- a/src/did/resolver.ts
+++ b/src/did/resolver.ts
@@ -4,6 +4,7 @@ import { getResolver as webGetResolver } from "web-did-resolver";
 import NodeCache from "node-cache";
 import { INFURA_API_KEY } from "../config";
 import { generateProvider } from "../common/utils";
+import { providerType } from "../types/core";
 
 export interface EthrResolverConfig {
   networks: Array<{
@@ -13,24 +14,43 @@ export interface EthrResolverConfig {
   }>;
 }
 
-export const getProviderConfig = () => {
-  const provider = generateProvider() as any;
+const buildConfigFromProvider = (provider: any): EthrResolverConfig | undefined => {
   const rpcUrl = provider?.connection?.url || "";
-  const networkName = provider?._network?.name === "homestead" ? "mainnet" : provider?._network?.name || "";
+  const rawName = provider?._network?.name;
+  const networkName = rawName === "homestead" ? "mainnet" : rawName || "";
+  if (!rpcUrl || !networkName) return undefined;
+  return { networks: [{ name: networkName, rpcUrl }] };
+};
 
-  if (!rpcUrl || !networkName) {
-    return { networks: [{ name: "mainnet", rpcUrl: `https://mainnet.infura.io/v3/${INFURA_API_KEY}` }] };
-  }
+export const getProviderConfig = (): EthrResolverConfig => {
+  return (
+    buildConfigFromProvider(generateProvider()) ?? {
+      networks: [{ name: "mainnet", rpcUrl: `https://mainnet.infura.io/v3/${INFURA_API_KEY}` }],
+    }
+  );
+};
 
-  return {
-    networks: [{ name: networkName, rpcUrl: rpcUrl }],
-  };
+export const getFallbackConfig = (): EthrResolverConfig => {
+  const primary = (process.env.PROVIDER_ENDPOINT_TYPE as providerType) || "infura";
+  const fallbackType: providerType = primary === "alchemy" ? "infura" : "alchemy";
+  const network = process.env.PROVIDER_NETWORK || "homestead";
+  const apiKey = fallbackType === "infura" ? process.env.INFURA_API_KEY || "" : process.env.ALCHEMY_API_KEY || "";
+
+  const provider = generateProvider({ providerType: fallbackType, network, apiKey });
+  const config = buildConfigFromProvider(provider);
+  if (!config) throw new Error(`Unable to build fallback resolver config for provider type "${fallbackType}"`);
+  return config;
 };
 
 const didResolutionCache = new NodeCache({ stdTTL: 5 * 60 }); // 5 min
 
 const defaultResolver = new Resolver({
   ...(ethrGetResolver(getProviderConfig()) as ResolverRegistry),
+  ...(webGetResolver() as ResolverRegistry),
+});
+
+const fallbackResolver = new Resolver({
+  ...(ethrGetResolver(getFallbackConfig()) as ResolverRegistry),
   ...(webGetResolver() as ResolverRegistry),
 });
 
@@ -45,7 +65,16 @@ export const createResolver = ({ ethrResolverConfig }: { ethrResolverConfig?: Et
 export const resolve = async (didUrl: string, resolver?: Resolver): Promise<DIDDocument | undefined> => {
   const cachedResult = didResolutionCache.get<DIDDocument>(didUrl);
   if (cachedResult) return cachedResult;
-  const didResolutionResult = resolver ? await resolver.resolve(didUrl) : await defaultResolver.resolve(didUrl);
+
+  const primary = resolver ?? defaultResolver;
+  let didResolutionResult;
+  try {
+    didResolutionResult = await primary.resolve(didUrl);
+    if (!didResolutionResult.didDocument) throw new Error("Empty didDocument from primary resolver");
+  } catch {
+    didResolutionResult = await fallbackResolver.resolve(didUrl);
+  }
+
   const did = didResolutionResult.didDocument || undefined;
   didResolutionCache.set(didUrl, did);
   return did;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced DID resolution with automatic fallback to secondary provider when primary resolution fails.
  * Support for configuring Alchemy and Infura API keys via environment variables.

* **Chores**
  * Updated @tradetrust-tt/dnsprove dependency to v2.21.0.

* **Tests**
  * Added test coverage for fallback configuration logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TradeTrust/tt-verify/pull/52)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->