### PR TITLE
fix: 0x-prefix bytes32 inputs for document store status checks

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -252,3 +252,9 @@ export const isBatchableDocumentStore = async (contract: DocumentStore): Promise
     return false;
   }
 };
+
+// OpenAttestation stores targetHash, merkleRoot, and proofs as unprefixed lowercase hex.
+// The new @trustvc/document-store typechain uses ethers v6, which strictly validates bytes32
+// inputs and rejects unprefixed hex with INVALID_ARGUMENT. Normalize before contract calls.
+export const ensureHexPrefix = (hash: string): string =>
+  typeof hash === "string" && hash.startsWith("0x") ? hash : `0x${hash}`;

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -257,4 +257,4 @@ export const isBatchableDocumentStore = async (contract: DocumentStore): Promise
 // The new @trustvc/document-store typechain uses ethers v6, which strictly validates bytes32
 // inputs and rejects unprefixed hex with INVALID_ARGUMENT. Normalize before contract calls.
 export const ensureHexPrefix = (hash: string): string =>
-  typeof hash === "string" && hash.startsWith("0x") ? hash : `0x${hash}`;
+  typeof hash === "string" && hash.slice(0, 2).toLowerCase() === "0x" ? `0x${hash.slice(2)}` : `0x${hash}`;

--- a/src/verifiers/documentStatus/documentStore/ethereumDocumentStoreStatus.test.ts
+++ b/src/verifiers/documentStatus/documentStore/ethereumDocumentStoreStatus.test.ts
@@ -457,7 +457,13 @@ describe("isIssuedOnDocumentStore", () => {
       await isIssuedOnDocumentStore({ documentStore, merkleRoot, targetHash, proofs, provider });
 
       expect(mockContract.supportsInterface).toHaveBeenCalledWith("0xdcfd0745");
-      expect(mockContract["isIssued(bytes32,bytes32,bytes32[])"]).toHaveBeenCalledWith(merkleRoot, targetHash, proofs);
+      // targetHash and proofs are 0x-prefixed by the verifier before being sent to the contract,
+      // because @trustvc/document-store's ethers v6 typechain strictly validates bytes32 inputs.
+      expect(mockContract["isIssued(bytes32,bytes32,bytes32[])"]).toHaveBeenCalledWith(
+        merkleRoot,
+        `0x${targetHash}`,
+        proofs.map((p) => `0x${p}`)
+      );
       expect(mockContract["isIssued(bytes32)"]).not.toHaveBeenCalled();
     });
 
@@ -496,7 +502,10 @@ describe("isIssuedOnDocumentStore", () => {
         provider,
       });
 
-      expect(mockContract["isIssued(bytes32,bytes32,bytes32[])"]).toHaveBeenCalledWith(merkleRoot, "112233", proofList);
+      expect(mockContract["isIssued(bytes32,bytes32,bytes32[])"]).toHaveBeenCalledWith(merkleRoot, "0x112233", [
+        "0xaabbcc",
+        "0xddeeff",
+      ]);
     });
   });
 

--- a/src/verifiers/documentStatus/documentStore/ethereumDocumentStoreStatus.ts
+++ b/src/verifiers/documentStatus/documentStore/ethereumDocumentStoreStatus.ts
@@ -7,7 +7,7 @@ import { CodedError } from "../../../common/error";
 import { withCodedErrorHandler } from "../../../common/errorHandler";
 import { decodeError, isRevokedOnDocumentStore } from "../utils";
 import { InvalidRevocationStatus, RevocationStatus, ValidRevocationStatusArray } from "../revocation.types";
-import { isBatchableDocumentStore } from "../../../common/utils";
+import { ensureHexPrefix, isBatchableDocumentStore } from "../../../common/utils";
 import {
   DocumentStoreIssuanceStatus,
   InvalidDocumentStoreIssuanceStatus,
@@ -54,7 +54,11 @@ export const isIssuedOnDocumentStore = async ({
 
     let issued: boolean;
     if (isBatchable) {
-      issued = await documentStoreContract["isIssued(bytes32,bytes32,bytes32[])"](merkleRoot, targetHash, proofs);
+      issued = await documentStoreContract["isIssued(bytes32,bytes32,bytes32[])"](
+        merkleRoot,
+        ensureHexPrefix(targetHash),
+        (proofs || []).map(ensureHexPrefix)
+      );
     } else {
       issued = await documentStoreContract["isIssued(bytes32)"](merkleRoot);
     }

--- a/src/verifiers/documentStatus/utils.ts
+++ b/src/verifiers/documentStatus/utils.ts
@@ -7,7 +7,7 @@ import {
   OpenAttestationDidSignedDocumentStatusCode,
 } from "../../types/error";
 import { CodedError } from "../../common/error";
-import { isBatchableDocumentStore } from "../../common/utils";
+import { ensureHexPrefix, isBatchableDocumentStore } from "../../common/utils";
 import { OcspResponderRevocationReason, RevocationStatus } from "./revocation.types";
 import { ValidOcspResponse, ValidOcspResponseRevoked } from "./didSigned/didSignedDocumentStatus.type";
 
@@ -89,8 +89,8 @@ export const isRevokedOnDocumentStore = async ({
     if (isBatchable) {
       revoked = (await documentStoreContract["isRevoked(bytes32,bytes32,bytes32[])"](
         merkleRoot,
-        targetHash,
-        proofs
+        ensureHexPrefix(targetHash),
+        (proofs || []).map(ensureHexPrefix)
       )) as boolean;
     } else {
       const intermediateHashes = getIntermediateHashes(targetHash, proofs);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hex string formatting in Ethereum document store verification workflows to ensure all hash and proof values are properly normalized before being sent to smart contract methods, significantly improving the overall compatibility, reliability, and consistency across both document issuance verification and revocation status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->